### PR TITLE
Login endpoint changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Install it yourself as:
 
 ## Usage
 
-First of all you need to get your API key:
+First of all you need to get your API key, User key and User name:
 
 * Register an account on http://thetvdb.com/?tab=register
 * When you are logged register an api key on http://thetvdb.com/?tab=apiregister
-* View your api keys on http://thetvdb.com/?tab=userinfo
+* View your api key, user key and user name on http://thetvdb.com/?tab=userinfo
 
 ```Go
 package main
@@ -32,7 +32,7 @@ import (
 )
 
 func main() {
-  c := tvdb.Client{Apikey: "YOUR API KEY"}
+  c := tvdb.Client{Apikey: "YOUR API KEY", Userkey: "YOUR USER KEY", Username: "YOUR USER NAME"}
   err := c.Login()
   if err != nil {
     panic(err)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install it yourself as:
 (optional) To run unit tests:
 
     $ cd $GOPATH/src/github.com/pioz/tvdb
-    $ TVDB_APIKEY=your_apikey go test -v
+    $ TVDB_APIKEY=your_apikey TVDB_USERKEY=your_userkey TVDB_USERNAME=your_username go test -v
 
 ## Usage
 

--- a/client.go
+++ b/client.go
@@ -26,8 +26,10 @@ import (
 // With its methods you can run almost all the requests provided in the TVDB
 // api.
 type Client struct {
-	// The TVDB API key. You can get one here http://thetvdb.com/?tab=apiregister
+	// The TVDB API key, User key, User name. You can get them here http://thetvdb.com/?tab=apiregister
 	Apikey string
+	Userkey string
+	Username string
 	// The language with which you want to obtain the data (if not set english is
 	// used)
 	Language string
@@ -41,7 +43,7 @@ const BaseURL string = "https://api.thetvdb.com"
 // Login is used to retrieve a valid token which will be used to make any other
 // requests to the TVDB api. The token is stored in the Client struct.
 func (c *Client) Login() error {
-	resp, err := c.performPOSTRequest("/login", map[string]string{"apikey": c.Apikey})
+	resp, err := c.performPOSTRequest("/login", map[string]string{"apikey": c.Apikey, "userkey": c.Userkey, "username": c.Username})
 	if err != nil {
 		return err
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleClient_Login() {
-	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Language: "en"}
+	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Username: os.Getenv("TVDB_USERNAME"), Userkey: os.Getenv("TVDB_USERKEY"), Language: "en"}
 	err := c.Login()
 	if err != nil {
 		panic(err)
@@ -17,7 +17,7 @@ func ExampleClient_Login() {
 }
 
 func ExampleClient_SearchByName() {
-	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Language: "en"}
+	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Username: os.Getenv("TVDB_USERNAME"), Userkey: os.Getenv("TVDB_USERKEY"), Language: "en"}
 	err := c.Login()
 	if err != nil {
 		panic(err)
@@ -31,7 +31,7 @@ func ExampleClient_SearchByName() {
 }
 
 func ExampleClient_BestSearch() {
-	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Language: "en"}
+	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Username: os.Getenv("TVDB_USERNAME"), Userkey: os.Getenv("TVDB_USERKEY"), Language: "en"}
 	err := c.Login()
 	if err != nil {
 		panic(err)
@@ -50,7 +50,7 @@ func ExampleClient_BestSearch() {
 }
 
 func ExampleClient_GetSeriesEpisodes() {
-	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Language: "en"}
+	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Username: os.Getenv("TVDB_USERNAME"), Userkey: os.Getenv("TVDB_USERKEY"), Language: "en"}
 	err := c.Login()
 	if err != nil {
 		panic(err)
@@ -68,7 +68,7 @@ func ExampleClient_GetSeriesEpisodes() {
 }
 
 func ExampleClient_GetSeriesFanartImages() {
-	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Language: "en"}
+	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Username: os.Getenv("TVDB_USERNAME"), Userkey: os.Getenv("TVDB_USERKEY"), Language: "en"}
 	err := c.Login()
 	if err != nil {
 		panic(err)
@@ -87,7 +87,7 @@ func ExampleClient_GetSeriesFanartImages() {
 }
 
 func ExampleSeries_GetSeasonEpisodes() {
-	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY")}
+	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Username: os.Getenv("TVDB_USERNAME"), Userkey: os.Getenv("TVDB_USERKEY"), Language: "en"}
 	err := c.Login()
 	if err != nil {
 		panic(err)
@@ -108,7 +108,7 @@ func ExampleSeries_GetSeasonEpisodes() {
 }
 
 func ExampleSeries_GetEpisode() {
-	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY")}
+	c := tvdb.Client{Apikey: os.Getenv("TVDB_APIKEY"), Username: os.Getenv("TVDB_USERNAME"), Userkey: os.Getenv("TVDB_USERKEY"), Language: "en"}
 	err := c.Login()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Currently, tvdb requires userkey and username in addition to apikey.

Probably, by the time of your last commit it still didn't need them.

Not sure if you're still using the library, if not just let me know to fork it properly.